### PR TITLE
Fix consistency of get return value

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -52,7 +52,7 @@ func (a *TimeAggregator) Get(date time.Time) int64 {
 	p := newPeriod(a.flags, date)
 
 	if _, ok := a.Values[p]; !ok {
-		return -1
+		return 0
 	}
 
 	return a.Values[p].Get(date)

--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -23,8 +23,8 @@ func (s *TimeAggregatorSuite) TestGetConsistency(c *C) {
 	a.Add(date2015January1, 1)
 
 	c.Assert(a.Get(date2015January1), Equals, int64(1))
-	c.Assert(a.Get(date2015January2), Equals, int64(-1))
-	c.Assert(a.Get(date2016January1), Equals, int64(-1))
+	c.Assert(a.Get(date2015January2), Equals, int64(0))
+	c.Assert(a.Get(date2016January1), Equals, int64(0))
 }
 
 func (s *TimeAggregatorSuite) TestAdd_YearHour(c *C) {

--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -18,6 +18,15 @@ func (s *TimeAggregatorSuite) TestNewTimeAggregator(c *C) {
 	c.Assert(err, Equals, InvalidOrderError)
 }
 
+func (s *TimeAggregatorSuite) TestGetConsistency(c *C) {
+	a, _ := NewTimeAggregator(Year, YearDay)
+	a.Add(date2015January1, 1)
+
+	c.Assert(a.Get(date2015January1), Equals, int64(1))
+	c.Assert(a.Get(date2015January2), Equals, int64(-1))
+	c.Assert(a.Get(date2016January1), Equals, int64(-1))
+}
+
 func (s *TimeAggregatorSuite) TestAdd_YearHour(c *C) {
 	a, _ := NewTimeAggregator(Year, Hour)
 	a.Add(date2014November, 15)
@@ -162,3 +171,6 @@ var date2015January = time.Date(2015, time.January, 12, 23, 59, 59, 0, time.UTC)
 var date2015December = time.Date(2015, time.December, 12, 23, 59, 59, 0, time.UTC)
 var date2015November = time.Date(2015, time.November, 12, 23, 59, 59, 0, time.UTC)
 var date2015November21h = time.Date(2015, time.November, 12, 21, 59, 59, 0, time.UTC)
+var date2015January1 = time.Date(2015, time.January, 1, 12, 0, 0, 0, time.UTC)
+var date2015January2 = time.Date(2015, time.January, 2, 12, 0, 0, 0, time.UTC)
+var date2016January1 = time.Date(2016, time.January, 1, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
WARNING: this change the public API, now failed gets returns 0 (zero) instead of -1.

Other projects using this repo will need to update their get failure checks if this PR is merged.

Please note that both the old `-1` and the new `0` return values are valid return values when asking for already stored dates (meaning you can not detect get failures).
